### PR TITLE
Some enhancements of nss-systemcerts

### DIFF
--- a/nss-systemcerts-import
+++ b/nss-systemcerts-import
@@ -35,6 +35,7 @@ CERTUTIL_BIN="/usr/bin/certutil"
 
 # Path to system-wide certificate repository
 SYS_CERT_REPO="/usr/share/ca-certificates"
+USER_CERT_REPO="/usr/local/share/ca-certificates"
 
 # certutil options when adding certificates
 TRUST_OPTS="C,C,C"
@@ -135,6 +136,12 @@ run chmod a+r ${NSS_DB}/*
 # Handle "accepted" certificates
 egrep -v '^(#|!|$)' "${CERT_STORE}" | while read cert; do
     run "${CERTUTIL_BIN}" -A -d "${NSS_DB_STRING}" -n $(basename "${cert}") -t "${TRUST_OPTS}" -i "${SYS_CERT_REPO}/${cert}"
+done
+
+# Handle "user-added" certificates
+shopt -s globstar
+for cert in ${USER_CERT_REPO}/**/*.crt; do # Whitespace-safe and recursive
+    run "${CERTUTIL_BIN}" -A -d "${NSS_DB_STRING}" -n $(basename "${cert}") -t "${TRUST_OPTS}" -i "${cert}"
 done
 
 # Handle "rejected" certificates

--- a/nss-systemcerts-import
+++ b/nss-systemcerts-import
@@ -128,7 +128,7 @@ fi
 
 # Create database
 run mkdir -p ${NSS_DB}
-run ${CERTUTIL_BIN} -N -d ${NSS_DB_STRING}
+run ${CERTUTIL_BIN} -N -d ${NSS_DB_STRING} --empty-password
 # Make sure the NSS database can be read by all users
 run chmod a+r ${NSS_DB}/*
 

--- a/nss-systemcerts-import
+++ b/nss-systemcerts-import
@@ -11,10 +11,10 @@
 # distribute, sublicense, and/or sell copies of the Software, and to
 # permit persons to whom the Software is furnished to do so, subject to
 # the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -139,5 +139,9 @@ done
 
 # Handle "rejected" certificates
 grep "^!" "${CERT_STORE}" | sed 's/^!//' | while read cert; do
+    if [ ! -f "${SYS_CERT_REPO}/${cert}" ]; then
+        echo "Distrusted certificate '${SYS_CERT_REPO}/${cert}' does not exist. Skipping..."
+        continue
+    fi
     run "${CERTUTIL_BIN}" -A -d "${NSS_DB_STRING}" -n $(basename "${cert}") -t "${DISTRUST_OPTS}" -i "${SYS_CERT_REPO}/${cert}"
 done


### PR DESCRIPTION
I added some enhancements to nss-systemcerts which made my life easier:
* Added --empty-password switch to certutil, so that it don't asks for a password on creation of the new store. (Needed for headless deployment)
* Skipping not existent certificates if they are distrusted. (Because on a new installation of Ubuntu, there are some distrusted certificates, which aren't in the store anyway.)
* Added support for user-added certificates in /usr/local/share/ca-certificates.